### PR TITLE
feat: add onTap callback to Ticketcher widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ and the Flutter guide for
 
 # Ticketcher
 
-Ticketcher is a powerful Flutter 
-package for creating beautiful, 
-highly customizable ticket-style 
-cards and widgets. Effortlessly 
-design event tickets, boarding 
-passes, coupons, and more with 
-support for unique border 
-patterns, 
-gradient backgrounds, custom 
-notches, and flexible section 
-layouts. Ticketcher makes it easy 
-to add professional, interactive 
-ticket designs to your Flutter 
-apps with just a few lines of 
+Ticketcher is a powerful Flutter
+package for creating beautiful,
+highly customizable ticket-style
+cards and widgets. Effortlessly
+design event tickets, boarding
+passes, coupons, and more with
+support for unique border
+patterns,
+gradient backgrounds, custom
+notches, and flexible section
+layouts. Ticketcher makes it easy
+to add professional, interactive
+ticket designs to your Flutter
+apps with just a few lines of
 code.
 
 
@@ -187,7 +187,9 @@ Ticketcher.vertical(
 )
 ```
 
-### Interactive Sections
+### Interactive Tickets
+
+#### Section-level Interaction
 
 Make your tickets interactive by adding tap callbacks to individual sections. Each section can have its own `onTap` function that gets called when the user taps on that specific section.
 
@@ -229,6 +231,10 @@ Ticketcher(
       },
     ),
   ],
+  onTap: () {
+    print('Whole ticket tapped!');
+    // Handle ticket tap
+  },
 )
 ```
 
@@ -251,6 +257,10 @@ Ticketcher(
       onTap: () => _performCheckIn(),
     ),
   ],
+  onTap: () {
+    print('Whole ticket tapped!');
+    // Handle ticket tap
+  },
 )
 ```
 
@@ -269,10 +279,31 @@ Ticketcher.horizontal(
       onTap: () => _showQRCode(),
     ),
   ],
+  onTap: () {
+    print('Whole ticket tapped!');
+    // Handle ticket tap
+  },
 )
 ```
 
 The `onTap` callback is completely optional. Sections without an `onTap` callback will not respond to taps, while sections with `onTap` will show a subtle tap effect and call your function when pressed.
+
+#### Whole-ticket Interaction
+
+You can also add a tap handler for the entire ticket using the `onTap` parameter. This works alongside section-level taps, with section taps taking precedence when tapping on a specific section.
+
+```dart
+Ticketcher.horizontal(
+  sections: [
+    // ... sections ...
+  ],
+  onTap: () {
+    // This will be called when tapping anywhere on the ticket
+    // except on sections that have their own onTap handler
+    print('Ticket tapped!');
+  },
+);
+```
 
 ### Border Patterns
 

--- a/example/.metadata
+++ b/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "be698c48a6750c8cb8e61c740ca9991bb947aba2"
+  revision: "d693b4b9dbac2acd4477aea4555ca6dcbea44ba2"
   channel: "stable"
 
 project_type: app
@@ -13,14 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      create_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
+      base_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
     - platform: android
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-    - platform: ios
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      create_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
+      base_revision: d693b4b9dbac2acd4477aea4555ca6dcbea44ba2
 
   # User provided section
 

--- a/example/lib/show_cases/flight.dart
+++ b/example/lib/show_cases/flight.dart
@@ -31,6 +31,9 @@ class FlightWidget extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 18, left: 4, right: 4, top: 4),
       child: Ticketcher(
+        onTap: () {
+          print('ticket taping');
+        },
         decoration: TicketcherDecoration(
           borderRadius: TicketRadius(radius: 20, corner: TicketCorner.top),
           backgroundColor: Theme.of(context).cardColor,
@@ -53,6 +56,9 @@ class FlightWidget extends StatelessWidget {
         sections: [
           // Header section
           Section(
+            onTap: () {
+              print('section tap');
+            },
             padding: EdgeInsets.all(4),
             child: Column(
               children: [

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -127,10 +127,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -188,17 +188,17 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   ticketcher:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/widgets/hticketcher.dart
+++ b/lib/src/widgets/hticketcher.dart
@@ -67,6 +67,7 @@ class HTicketcher extends StatefulWidget {
   /// This includes properties like border radius, background color,
   /// border style, and divider style.
   final TicketcherDecoration decoration;
+   final VoidCallback? onTap;
 
   /// Creates a new [HTicketcher].
   ///
@@ -80,6 +81,7 @@ class HTicketcher extends StatefulWidget {
     this.notchRadius = 10.0,
     this.height,
     this.decoration = const TicketcherDecoration(),
+    this.onTap,
   }) : assert(
          sections.length >= 2,
          'HTicketcher must have at least 2 sections',
@@ -246,50 +248,53 @@ class _HTicketcherState extends State<HTicketcher> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: widget.height,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final ticketWidget = BlurWrapper(
-            blurEffect: widget.decoration.blurEffect,
-            notchRadius: widget.notchRadius,
-            decoration: widget.decoration,
-            sectionMeasurements: _sectionWidths,
-            isVertical: false,
-            child: IntrinsicWidth(
-              child: CustomPaint(
-                painter: HTicketcherPainter(
-                  notchRadius: widget.notchRadius,
-                  decoration: widget.decoration,
-                  sectionWidths: _sectionWidths,
-                  sections: widget.sections,
-                  decorationBackgroundImage: _decorationBackgroundImage,
-                  sectionBackgroundImages: _sectionBackgroundImages,
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: List.generate(widget.sections.length, (index) {
-                    final section = widget.sections[index];
-                    return Expanded(
-                      flex: (section.widthFactor ?? 1.0).round(),
-                      child: GestureDetector(
-                        onTap: section.onTap,
-                        child: Container(
-                          key: _sectionKeys[index],
-                          padding: section.padding,
-                          child: section.child,
+    return GestureDetector(
+      onTap: widget.onTap,
+      child: SizedBox(
+        height: widget.height,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final ticketWidget = BlurWrapper(
+              blurEffect: widget.decoration.blurEffect,
+              notchRadius: widget.notchRadius,
+              decoration: widget.decoration,
+              sectionMeasurements: _sectionWidths,
+              isVertical: false,
+              child: IntrinsicWidth(
+                child: CustomPaint(
+                  painter: HTicketcherPainter(
+                    notchRadius: widget.notchRadius,
+                    decoration: widget.decoration,
+                    sectionWidths: _sectionWidths,
+                    sections: widget.sections,
+                    decorationBackgroundImage: _decorationBackgroundImage,
+                    sectionBackgroundImages: _sectionBackgroundImages,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: List.generate(widget.sections.length, (index) {
+                      final section = widget.sections[index];
+                      return Expanded(
+                        flex: (section.widthFactor ?? 1.0).round(),
+                        child: GestureDetector(
+                          onTap: section.onTap,
+                          child: Container(
+                            key: _sectionKeys[index],
+                            padding: section.padding,
+                            child: section.child,
+                          ),
                         ),
-                      ),
-                    );
-                  }),
+                      );
+                    }),
+                  ),
                 ),
               ),
-            ),
-          );
+            );
 
-          // Build with overlays (watermark)
-          return _buildWithOverlays(ticketWidget);
-        },
+            // Build with overlays (watermark)
+            return _buildWithOverlays(ticketWidget);
+          },
+        ),
       ),
     );
   }

--- a/lib/src/widgets/ticketcher.dart
+++ b/lib/src/widgets/ticketcher.dart
@@ -56,7 +56,6 @@ class Ticketcher extends StatelessWidget {
   /// Each section represents a distinct part of the ticket with its own content
   /// and padding. The sections are arranged based on the ticket orientation.
   final List<Section> sections;
-
   /// The radius of the notches between ticket sections.
   ///
   /// This determines how rounded the cutouts between sections will be.
@@ -87,6 +86,8 @@ class Ticketcher extends StatelessWidget {
   /// If false, the ticket will be rendered using [VTicketcher].
   final bool isHorizontal;
 
+  final VoidCallback? onTap;
+
   /// Creates a new [Ticketcher].
   ///
   /// The [sections] parameter must contain at least 2 sections.
@@ -102,6 +103,7 @@ class Ticketcher extends StatelessWidget {
     this.height,
     this.decoration = const TicketcherDecoration(),
     this.isHorizontal = false,
+    this.onTap,
   }) : assert(sections.length >= 2, 'Ticketcher must have at least 2 sections');
 
   /// Creates a new vertical [Ticketcher].
@@ -152,6 +154,7 @@ class Ticketcher extends StatelessWidget {
         notchRadius: notchRadius,
         height: height,
         decoration: decoration,
+        onTap: onTap,
       );
     }
     return VTicketcher(
@@ -159,6 +162,7 @@ class Ticketcher extends StatelessWidget {
       notchRadius: notchRadius,
       width: width,
       decoration: decoration,
+      onTap: onTap,
     );
   }
 }

--- a/lib/src/widgets/vticketcher.dart
+++ b/lib/src/widgets/vticketcher.dart
@@ -67,6 +67,7 @@ class VTicketcher extends StatefulWidget {
   /// This includes properties like border radius, background color,
   /// border style, and divider style.
   final TicketcherDecoration decoration;
+   final VoidCallback? onTap;
 
   /// Creates a new [VTicketcher].
   ///
@@ -80,6 +81,7 @@ class VTicketcher extends StatefulWidget {
     this.notchRadius = 10.0,
     this.width,
     this.decoration = const TicketcherDecoration(),
+    this.onTap,
   }) : assert(
          sections.length >= 2,
          'VTicketcher must have at least 2 sections',
@@ -255,47 +257,50 @@ class _VTicketcherState extends State<VTicketcher> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: widget.width,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final ticketWidget = BlurWrapper(
-            blurEffect: widget.decoration.blurEffect,
-            notchRadius: widget.notchRadius,
-            decoration: widget.decoration,
-            sectionMeasurements: _sectionHeights,
-            isVertical: true,
-            child: IntrinsicHeight(
-              child: CustomPaint(
-                painter: VTicketcherPainter(
-                  notchRadius: widget.notchRadius,
-                  decoration: widget.decoration,
-                  sectionHeights: _sectionHeights,
-                  sections: widget.sections,
-                  decorationBackgroundImage: _decorationBackgroundImage,
-                  sectionBackgroundImages: _sectionBackgroundImages,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: List.generate(widget.sections.length, (index) {
-                    final section = widget.sections[index];
-                    return GestureDetector(
-                      onTap: section.onTap,
-                      child: Container(
-                        key: _sectionKeys[index],
-                        padding: section.padding,
-                        child: section.child,
-                      ),
-                    );
-                  }),
+    return GestureDetector(
+      onTap: widget.onTap,
+      child: SizedBox(
+        width: widget.width,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final ticketWidget = BlurWrapper(
+              blurEffect: widget.decoration.blurEffect,
+              notchRadius: widget.notchRadius,
+              decoration: widget.decoration,
+              sectionMeasurements: _sectionHeights,
+              isVertical: true,
+              child: IntrinsicHeight(
+                child: CustomPaint(
+                  painter: VTicketcherPainter(
+                    notchRadius: widget.notchRadius,
+                    decoration: widget.decoration,
+                    sectionHeights: _sectionHeights,
+                    sections: widget.sections,
+                    decorationBackgroundImage: _decorationBackgroundImage,
+                    sectionBackgroundImages: _sectionBackgroundImages,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: List.generate(widget.sections.length, (index) {
+                      final section = widget.sections[index];
+                      return GestureDetector(
+                        onTap: section.onTap,
+                        child: Container(
+                          key: _sectionKeys[index],
+                          padding: section.padding,
+                          child: section.child,
+                        ),
+                      );
+                    }),
+                  ),
                 ),
               ),
-            ),
-          );
+            );
 
-          // Build with overlays (watermark)
-          return _buildWithOverlays(ticketWidget);
-        },
+            // Build with overlays (watermark)
+            return _buildWithOverlays(ticketWidget);
+          },
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
- Added optional onTap callback to Ticketcher, HTicketcher, and VTicketcher
- Wrapped ticket content in GestureDetector to handle taps on the entire ticket
- Maintained backward compatibility with existing section-level onTap handlers
- Updated pubspec.lock with dependency changes

This allows users to handle taps on the entire ticket widget while preserving existing section-level tap functionality.