### PR TITLE
feat: stitching border (TicketStitch) — 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.0
+
+- **Stitching border**: new `TicketStitch` on `TicketcherDecoration.stitch` — an
+  inset dashed "thread" line that follows the full outline (rounded corners +
+  section notches) for a sewn/stitched look. Configurable `color`, `inset`,
+  `length`, `spacing`, `thickness`, and `cap`. Works in both orientations and is
+  independent of `border` / `borderDash`. Purely additive.
+
 ## 2.1.0
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ code.
 - ✂️ **Dashed Outer Border**: Classic coupon cut-line that follows notches and corners
 - 🪄 **Per-Boundary Dividers**: A different divider style at every section boundary
 - 🕳️ **Punch Holes**: True cutouts for lanyards and tags
-- 🧵 **Stitching border**: Inset dashed "thread" line that follows the full outline for a sewn/coupon look
+- 🧵 **Stitching Border**: Inset dashed "thread" line that follows the full outline for a sewn/coupon look
 - Custom border radius for any corner
 - Shadow effects
 - Section padding control
@@ -1386,6 +1386,8 @@ TicketcherDecoration(
 
 Requires `border` or `borderGradient`. The dashes follow the full ticket outline.
 
+## 2.2.0 Features
+
 ### Stitching Border
 
 Add an inset dashed "thread" line that follows the ticket outline — corners and
@@ -1442,27 +1444,6 @@ TicketcherDecoration(
 ```
 
 Holes are true cutouts — background, shadows, blur, and the border stroke all respect them.
-
-## 2.2.0 Features
-
-### Stitching Border
-
-```dart
-TicketcherDecoration(
-  backgroundColor: const Color(0xFF19A8B8),
-  borderRadius: const TicketRadius(radius: 24),
-  stitch: const TicketStitch(
-    color: Colors.white,
-    inset: 12,
-    length: 7,
-    spacing: 7,
-    thickness: 2,
-    cap: StrokeCap.round,
-  ),
-)
-```
-
-Works in both vertical and horizontal orientations. Independent of `border` / `borderDash`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ code.
   - [Dashed Outer Border](#dashed-outer-border)
   - [Per-Boundary Dividers](#per-boundary-dividers)
   - [Punch Holes](#punch-holes)
+- [2.2.0 Features](#220-features)
+  - [Stitching Border](#stitching-border)
 - [Important Usage Notes](#important-usage-notes)
   - [Assertions](#assertions)
   - [Best Practices](#best-practices)
@@ -122,6 +124,7 @@ code.
 - ✂️ **Dashed Outer Border**: Classic coupon cut-line that follows notches and corners
 - 🪄 **Per-Boundary Dividers**: A different divider style at every section boundary
 - 🕳️ **Punch Holes**: True cutouts for lanyards and tags
+- 🧵 **Stitching border**: Inset dashed "thread" line that follows the full outline for a sewn/coupon look
 - Custom border radius for any corner
 - Shadow effects
 - Section padding control
@@ -136,7 +139,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  ticketcher: ^2.1.0
+  ticketcher: ^2.2.0
 ```
 
 ## Usage
@@ -1383,6 +1386,37 @@ TicketcherDecoration(
 
 Requires `border` or `borderGradient`. The dashes follow the full ticket outline.
 
+### Stitching Border
+
+Add an inset dashed "thread" line that follows the ticket outline — corners and
+section notches included — for a sewn / coupon look. It's independent of the
+outer `border`, so you can use either or both.
+
+```dart
+Ticketcher(
+  decoration: TicketcherDecoration(
+    backgroundColor: const Color(0xFF19A8B8),
+    borderRadius: const TicketRadius(radius: 24),
+    stitch: const TicketStitch(
+      color: Colors.white,
+      inset: 12,     // distance from the edge
+      length: 7,     // stitch (dash) length
+      spacing: 7,    // gap between stitches
+      thickness: 2,
+      cap: StrokeCap.round,
+    ),
+  ),
+  sections: [
+    Section(child: Text('ADMIT ONE')),
+    Section(child: Text('Row C · Seat 42')),
+  ],
+)
+```
+
+Notches are wrapped with a smooth rounded arc regardless of `notchStyle`. Keep
+`inset` below half the ticket's smallest dimension. Border patterns and punch
+holes are not traced by the stitch.
+
 ### Per-Boundary Dividers
 
 ```dart
@@ -1408,6 +1442,27 @@ TicketcherDecoration(
 ```
 
 Holes are true cutouts — background, shadows, blur, and the border stroke all respect them.
+
+## 2.2.0 Features
+
+### Stitching Border
+
+```dart
+TicketcherDecoration(
+  backgroundColor: const Color(0xFF19A8B8),
+  borderRadius: const TicketRadius(radius: 24),
+  stitch: const TicketStitch(
+    color: Colors.white,
+    inset: 12,
+    length: 7,
+    spacing: 7,
+    thickness: 2,
+    cap: StrokeCap.round,
+  ),
+)
+```
+
+Works in both vertical and horizontal orientations. Independent of `border` / `borderDash`.
 
 ## Contributing
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 import 'show_cases/circle_divider.dart';
 import 'show_cases/wave_divider.dart';
 import 'show_cases/smooth_wave_divider.dart';
+import 'show_cases/stitching_showcase.dart';
 
 class ExampleItem {
   final IconData icon;
@@ -38,6 +39,12 @@ class ExampleItem {
 
 final List<ExampleItem> examples = [
   // New Features v2.1.0
+  ExampleItem(
+    icon: Icons.straighten,
+    title: 'Stitching Border',
+    subtitle: 'Inset dashed thread following the outline',
+    page: const StitchingShowcase(),
+  ),
   ExampleItem(
     icon: Icons.new_releases_outlined,
     title: '2.1.0 Features',

--- a/example/lib/show_cases/stitching_showcase.dart
+++ b/example/lib/show_cases/stitching_showcase.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:ticketcher/ticketcher.dart';
+
+class StitchingShowcase extends StatelessWidget {
+  const StitchingShowcase({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const teal = Color(0xFF19A8B8);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Stitching Border')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            // Vertical coupon — white thread on teal, the reference look.
+            VTicketcher(
+              width: 300,
+              decoration: const TicketcherDecoration(
+                backgroundColor: teal,
+                borderRadius: TicketRadius(radius: 24),
+                stitch: TicketStitch(
+                  color: Colors.white,
+                  inset: 12,
+                  length: 7,
+                  spacing: 7,
+                  thickness: 2,
+                ),
+              ),
+              sections: const [
+                Section(
+                  padding: EdgeInsets.all(24),
+                  child: SizedBox(
+                    height: 90,
+                    child: Center(
+                      child: Text(
+                        'ADMIT ONE',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 22,
+                          fontWeight: FontWeight.bold,
+                          letterSpacing: 2,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                Section(
+                  padding: EdgeInsets.all(24),
+                  child: SizedBox(
+                    height: 70,
+                    child: Center(
+                      child: Text(
+                        'No. 042 · Row C',
+                        style: TextStyle(color: Colors.white, fontSize: 15),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+
+            // Horizontal — gold thread, larger inset.
+            Ticketcher.horizontal(
+              height: 150,
+              decoration: const TicketcherDecoration(
+                backgroundColor: Color(0xFF2B2B3A),
+                borderRadius: TicketRadius(radius: 18),
+                stitch: TicketStitch(
+                  color: Color(0xFFF4C95D),
+                  inset: 10,
+                  length: 6,
+                  spacing: 5,
+                  thickness: 2,
+                ),
+              ),
+              sections: const [
+                Section(
+                  widthFactor: 1,
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: Text(
+                      '50%\nOFF',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Color(0xFFF4C95D),
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                Section(
+                  widthFactor: 2,
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: Text(
+                      'CODE: STITCH50',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+
+            // Stitch + solid border together (independent layers).
+            VTicketcher(
+              width: 300,
+              decoration: TicketcherDecoration(
+                backgroundColor: Colors.white,
+                borderRadius: const TicketRadius(radius: 16),
+                border: Border.all(color: Colors.indigo.shade300, width: 2),
+                stitch: TicketStitch(
+                  color: Colors.indigo.shade300,
+                  inset: 9,
+                  length: 5,
+                  spacing: 5,
+                  thickness: 1.5,
+                ),
+              ),
+              sections: const [
+                Section(
+                  padding: EdgeInsets.all(20),
+                  child: SizedBox(
+                    height: 70,
+                    child: Center(child: Text('Border + stitch')),
+                  ),
+                ),
+                Section(
+                  padding: EdgeInsets.all(20),
+                  child: SizedBox(
+                    height: 60,
+                    child: Center(child: Text('two independent layers')),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -198,7 +198,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.0"
+    version: "2.2.0"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/models/ticket_stitch.dart
+++ b/lib/src/models/ticket_stitch.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+/// A dashed "thread" line inset from the ticket edge, following the full
+/// outline (rounded corners + section notches) to create a sewn / stitched look.
+///
+/// Set on `TicketcherDecoration.stitch`. Independent of `border` / `borderDash`
+/// — it draws as a separate inset line and does not require a border. Works in
+/// both vertical and horizontal orientations.
+///
+/// Notches are wrapped with a smooth rounded arc regardless of
+/// `notchStyle.shape` (thread curves naturally). Edge border patterns
+/// (`bottomBorderStyle`, etc.) and `punchHoles` are not traced.
+///
+/// Keep [inset] below half the ticket's smallest dimension; beyond that the
+/// inset line collapses and the stitch is not drawn.
+///
+/// Example:
+/// ```dart
+/// TicketcherDecoration(
+///   stitch: TicketStitch(color: Colors.white, inset: 10, length: 6, spacing: 6),
+/// )
+/// ```
+@immutable
+class TicketStitch {
+  /// Thread color. Defaults to white.
+  final Color color;
+
+  /// Distance from the ticket edge to the stitch line, in logical pixels. > 0.
+  final double inset;
+
+  /// Length of each stitch (dash) in logical pixels. > 0.
+  final double length;
+
+  /// Gap between stitches in logical pixels. > 0.
+  final double spacing;
+
+  /// Stroke width of the thread in logical pixels. > 0.
+  final double thickness;
+
+  /// Cap at each stitch end. [StrokeCap.round] gives the thread look.
+  final StrokeCap cap;
+
+  // `< double.infinity` (rather than `.isFinite`) keeps the assert
+  // const-evaluable; NaN already fails the `> 0` check.
+  const TicketStitch({
+    this.color = Colors.white,
+    this.inset = 10,
+    this.length = 6,
+    this.spacing = 6,
+    this.thickness = 2,
+    this.cap = StrokeCap.round,
+  })  : assert(inset > 0 && inset < double.infinity,
+            'inset must be a finite positive number'),
+        assert(length > 0 && length < double.infinity,
+            'length must be a finite positive number'),
+        assert(spacing > 0 && spacing < double.infinity,
+            'spacing must be a finite positive number'),
+        assert(thickness > 0 && thickness < double.infinity,
+            'thickness must be a finite positive number');
+
+  TicketStitch copyWith({
+    Color? color,
+    double? inset,
+    double? length,
+    double? spacing,
+    double? thickness,
+    StrokeCap? cap,
+  }) {
+    return TicketStitch(
+      color: color ?? this.color,
+      inset: inset ?? this.inset,
+      length: length ?? this.length,
+      spacing: spacing ?? this.spacing,
+      thickness: thickness ?? this.thickness,
+      cap: cap ?? this.cap,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TicketStitch &&
+        other.color == color &&
+        other.inset == inset &&
+        other.length == length &&
+        other.spacing == spacing &&
+        other.thickness == thickness &&
+        other.cap == cap;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(color, inset, length, spacing, thickness, cap);
+}

--- a/lib/src/models/ticketcher_decoration.dart
+++ b/lib/src/models/ticketcher_decoration.dart
@@ -7,6 +7,7 @@ import 'notch_shape.dart';
 import 'punch_hole.dart';
 import 'ticket_divider.dart';
 import 'ticket_radius.dart';
+import 'ticket_stitch.dart';
 import 'ticket_watermark.dart';
 
 /// A class that defines the stacked layers effect for a ticket.
@@ -110,6 +111,7 @@ class StackEffect {
 /// * Multiple layered shadows using [shadows]
 /// * Top border pattern using [topBorderStyle] (vertical tickets only)
 /// * Dashed outer border using [borderDash]
+/// * Stitched (inset dashed) border using [stitch]
 /// * Punch holes using [punchHoles]
 @immutable
 class TicketcherDecoration {
@@ -148,6 +150,11 @@ class TicketcherDecoration {
   ///
   /// Only takes effect when [border] or [borderGradient] is set.
   final BorderDash? borderDash;
+
+  /// Inset dashed "thread" line following the outline, for a stitched look.
+  ///
+  /// Independent of [border] / [borderDash]. Both orientations.
+  final TicketStitch? stitch;
 
   /// Holes punched through the ticket shape.
   ///
@@ -192,6 +199,7 @@ class TicketcherDecoration {
     this.shadows,
     this.topBorderStyle,
     this.borderDash,
+    this.stitch,
     this.punchHoles,
     this.stackEffect = const StackEffect(),
     this.watermark,
@@ -221,6 +229,7 @@ class TicketcherDecoration {
     List<BoxShadow>? shadows,
     BorderPattern? topBorderStyle,
     BorderDash? borderDash,
+    TicketStitch? stitch,
     List<PunchHole>? punchHoles,
     StackEffect? stackEffect,
     TicketWatermark? watermark,
@@ -246,6 +255,7 @@ class TicketcherDecoration {
       shadows: shadows ?? this.shadows,
       topBorderStyle: topBorderStyle ?? this.topBorderStyle,
       borderDash: borderDash ?? this.borderDash,
+      stitch: stitch ?? this.stitch,
       punchHoles: punchHoles ?? this.punchHoles,
       stackEffect: stackEffect ?? this.stackEffect,
       watermark: watermark ?? this.watermark,
@@ -278,6 +288,7 @@ class TicketcherDecoration {
         listEquals(other.shadows, shadows) &&
         other.topBorderStyle == topBorderStyle &&
         other.borderDash == borderDash &&
+        other.stitch == stitch &&
         listEquals(other.punchHoles, punchHoles) &&
         other.stackEffect == stackEffect &&
         other.watermark == watermark &&
@@ -305,6 +316,7 @@ class TicketcherDecoration {
     shadows == null ? null : Object.hashAll(shadows!),
     topBorderStyle,
     borderDash,
+    stitch,
     punchHoles == null ? null : Object.hashAll(punchHoles!),
     stackEffect,
     watermark,

--- a/lib/src/painters/hticketcher_painter.dart
+++ b/lib/src/painters/hticketcher_painter.dart
@@ -11,6 +11,7 @@ import '../models/ticket_watermark.dart';
 import '_equality.dart';
 import 'path_dasher.dart';
 import 'ticket_path_builder.dart';
+import '../models/border_dash.dart';
 
 /// A custom painter that draws a horizontal ticket with customizable sections, borders, and dividers.
 ///
@@ -119,6 +120,9 @@ class HTicketcherPainter extends CustomPainter {
   final Paint _backgroundPaint = Paint()..style = PaintingStyle.fill;
   final Paint _sectionFillPaint = Paint()..style = PaintingStyle.fill;
   final Paint _borderPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeJoin = StrokeJoin.round;
+  final Paint _stitchPaint = Paint()
     ..style = PaintingStyle.stroke
     ..strokeJoin = StrokeJoin.round;
   final Paint _dividerLinePaint = Paint()..style = PaintingStyle.stroke;
@@ -1028,6 +1032,28 @@ class HTicketcherPainter extends CustomPainter {
           ? dashPath(outline, decoration.borderDash!)
           : outline;
       canvas.drawPath(strokePath, borderPaint);
+    }
+
+    // Draw the stitch line if specified: an inset dashed thread following the
+    // outline. Skipped when the inset would collapse the inset contour.
+    final stitch = decoration.stitch;
+    if (stitch != null && stitch.inset * 2 < size.shortestSide) {
+      final stitchOutline = TicketPathBuilder.buildHorizontalStitchPath(
+        size: size,
+        notchRadius: notchRadius,
+        decoration: decoration,
+        sectionWidths: sectionWidths,
+        inset: stitch.inset,
+      );
+      final stitchPaint = _stitchPaint
+        ..color = stitch.color
+        ..strokeWidth = stitch.thickness
+        ..strokeCap = stitch.cap;
+      canvas.drawPath(
+        dashPath(stitchOutline,
+            BorderDash(dash: stitch.length, gap: stitch.spacing)),
+        stitchPaint,
+      );
     }
 
     // Draw dividers between ticket sections. A section's `dividerAfter`

--- a/lib/src/painters/ticket_path_builder.dart
+++ b/lib/src/painters/ticket_path_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import '../models/notch_shape.dart';
 import '../models/punch_hole.dart';
@@ -462,6 +464,198 @@ class TicketPathBuilder {
     final holes = decoration.punchHoles;
     if (holes == null || holes.isEmpty) return path;
     return subtractPunchHoles(path, size, holes);
+  }
+
+  /// Builds the inset "stitch" outline for a vertical ticket: the contour
+  /// offset inward by [inset], with corner radii reduced by [inset] and each
+  /// notch wrapped by a rounded arc of radius `notchRadius + inset` centred on
+  /// the original notch position. Border patterns and punch holes are ignored.
+  static Path buildVerticalStitchPath({
+    required Size size,
+    required double notchRadius,
+    required TicketcherDecoration decoration,
+    required List<double> sectionHeights,
+    required double inset,
+  }) {
+    final path = Path();
+    final r = decoration.borderRadius.radius;
+    final corner = decoration.borderRadius.corner;
+    final rr = math.max(0.0, r - inset);
+    final bool cw = decoration.borderRadius.direction == RadiusDirection.inward;
+
+    final double left = inset;
+    final double top = inset;
+    final double right = size.width - inset;
+    final double bottom = size.height - inset;
+
+    bool shouldRoundCorner(TicketCorner targetCorner) {
+      switch (corner) {
+        case TicketCorner.all:
+          return true;
+        case TicketCorner.top:
+          return targetCorner == TicketCorner.topLeft ||
+              targetCorner == TicketCorner.topRight;
+        case TicketCorner.bottom:
+          return targetCorner == TicketCorner.bottomLeft ||
+              targetCorner == TicketCorner.bottomRight;
+        case TicketCorner.none:
+          return false;
+        default:
+          return corner == targetCorner;
+      }
+    }
+
+    bool round(TicketCorner c) => shouldRoundCorner(c) && rr > 0;
+
+    final cumulative = <double>[];
+    double acc = 0;
+    for (final h in sectionHeights) {
+      acc += h;
+      cumulative.add(acc);
+    }
+
+    final nr = decoration.notchStyle?.radius ?? notchRadius;
+    final notchR = nr + inset;
+    final yj = math.sqrt(nr * nr + 2 * nr * inset);
+
+    path.moveTo(round(TicketCorner.topLeft) ? left + rr : left, top);
+
+    if (round(TicketCorner.topRight)) {
+      path.lineTo(right - rr, top);
+      path.arcToPoint(Offset(right, top + rr),
+          radius: Radius.circular(rr), clockwise: cw);
+    } else {
+      path.lineTo(right, top);
+    }
+
+    for (int i = 0; i < sectionHeights.length - 1; i++) {
+      final cy = cumulative[i];
+      path.lineTo(right, cy - yj);
+      path.arcToPoint(Offset(right, cy + yj),
+          radius: Radius.circular(notchR), clockwise: false);
+    }
+
+    path.lineTo(right, round(TicketCorner.bottomRight) ? bottom - rr : bottom);
+    if (round(TicketCorner.bottomRight)) {
+      path.arcToPoint(Offset(right - rr, bottom),
+          radius: Radius.circular(rr), clockwise: cw);
+    }
+
+    path.lineTo(round(TicketCorner.bottomLeft) ? left + rr : left, bottom);
+    if (round(TicketCorner.bottomLeft)) {
+      path.arcToPoint(Offset(left, bottom - rr),
+          radius: Radius.circular(rr), clockwise: cw);
+    }
+
+    for (int i = sectionHeights.length - 2; i >= 0; i--) {
+      final cy = cumulative[i];
+      path.lineTo(left, cy + yj);
+      path.arcToPoint(Offset(left, cy - yj),
+          radius: Radius.circular(notchR), clockwise: false);
+    }
+
+    path.lineTo(left, round(TicketCorner.topLeft) ? top + rr : top);
+    if (round(TicketCorner.topLeft)) {
+      path.arcToPoint(Offset(left + rr, top),
+          radius: Radius.circular(rr), clockwise: cw);
+    }
+
+    path.close();
+    return path;
+  }
+
+  /// Horizontal mirror of [buildVerticalStitchPath]: notches sit on the top and
+  /// bottom edges.
+  static Path buildHorizontalStitchPath({
+    required Size size,
+    required double notchRadius,
+    required TicketcherDecoration decoration,
+    required List<double> sectionWidths,
+    required double inset,
+  }) {
+    final path = Path();
+    final r = decoration.borderRadius.radius;
+    final corner = decoration.borderRadius.corner;
+    final rr = math.max(0.0, r - inset);
+    final bool cw = decoration.borderRadius.direction == RadiusDirection.inward;
+
+    final double left = inset;
+    final double top = inset;
+    final double right = size.width - inset;
+    final double bottom = size.height - inset;
+
+    bool shouldRoundCorner(TicketCorner targetCorner) {
+      switch (corner) {
+        case TicketCorner.all:
+          return true;
+        case TicketCorner.top:
+          return targetCorner == TicketCorner.topLeft ||
+              targetCorner == TicketCorner.topRight;
+        case TicketCorner.bottom:
+          return targetCorner == TicketCorner.bottomLeft ||
+              targetCorner == TicketCorner.bottomRight;
+        case TicketCorner.none:
+          return false;
+        default:
+          return corner == targetCorner;
+      }
+    }
+
+    bool round(TicketCorner c) => shouldRoundCorner(c) && rr > 0;
+
+    final cumulative = <double>[];
+    double acc = 0;
+    for (final w in sectionWidths) {
+      acc += w;
+      cumulative.add(acc);
+    }
+
+    final nr = decoration.notchStyle?.radius ?? notchRadius;
+    final notchR = nr + inset;
+    final xj = math.sqrt(nr * nr + 2 * nr * inset);
+
+    path.moveTo(round(TicketCorner.topLeft) ? left + rr : left, top);
+
+    for (int i = 0; i < sectionWidths.length - 1; i++) {
+      final cx = cumulative[i];
+      path.lineTo(cx - xj, top);
+      path.arcToPoint(Offset(cx + xj, top),
+          radius: Radius.circular(notchR), clockwise: false);
+    }
+
+    path.lineTo(round(TicketCorner.topRight) ? right - rr : right, top);
+    if (round(TicketCorner.topRight)) {
+      path.arcToPoint(Offset(right, top + rr),
+          radius: Radius.circular(rr), clockwise: cw);
+    }
+
+    path.lineTo(right, round(TicketCorner.bottomRight) ? bottom - rr : bottom);
+    if (round(TicketCorner.bottomRight)) {
+      path.arcToPoint(Offset(right - rr, bottom),
+          radius: Radius.circular(rr), clockwise: cw);
+    }
+
+    for (int i = sectionWidths.length - 2; i >= 0; i--) {
+      final cx = cumulative[i];
+      path.lineTo(cx + xj, bottom);
+      path.arcToPoint(Offset(cx - xj, bottom),
+          radius: Radius.circular(notchR), clockwise: false);
+    }
+
+    path.lineTo(round(TicketCorner.bottomLeft) ? left + rr : left, bottom);
+    if (round(TicketCorner.bottomLeft)) {
+      path.arcToPoint(Offset(left, bottom - rr),
+          radius: Radius.circular(rr), clockwise: cw);
+    }
+
+    path.lineTo(left, round(TicketCorner.topLeft) ? top + rr : top);
+    if (round(TicketCorner.topLeft)) {
+      path.arcToPoint(Offset(left + rr, top),
+          radius: Radius.circular(rr), clockwise: cw);
+    }
+
+    path.close();
+    return path;
   }
 
   /// Subtracts [holes] from [outline] and returns the combined path.

--- a/lib/src/painters/vticketcher_painter.dart
+++ b/lib/src/painters/vticketcher_painter.dart
@@ -11,6 +11,7 @@ import '../models/ticket_watermark.dart';
 import '_equality.dart';
 import 'path_dasher.dart';
 import 'ticket_path_builder.dart';
+import '../models/border_dash.dart';
 
 /// A custom painter that draws a vertical ticket with customizable sections, borders, and dividers.
 ///
@@ -101,6 +102,9 @@ class VTicketcherPainter extends CustomPainter {
   final Paint _backgroundPaint = Paint()..style = PaintingStyle.fill;
   final Paint _sectionFillPaint = Paint()..style = PaintingStyle.fill;
   final Paint _borderPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeJoin = StrokeJoin.round;
+  final Paint _stitchPaint = Paint()
     ..style = PaintingStyle.stroke
     ..strokeJoin = StrokeJoin.round;
   final Paint _dividerLinePaint = Paint()..style = PaintingStyle.stroke;
@@ -1028,6 +1032,28 @@ class VTicketcherPainter extends CustomPainter {
           ? dashPath(outline, decoration.borderDash!)
           : outline;
       canvas.drawPath(strokePath, borderPaint);
+    }
+
+    // Draw the stitch line if specified: an inset dashed thread following the
+    // outline. Skipped when the inset would collapse the inset contour.
+    final stitch = decoration.stitch;
+    if (stitch != null && stitch.inset * 2 < size.shortestSide) {
+      final stitchOutline = TicketPathBuilder.buildVerticalStitchPath(
+        size: size,
+        notchRadius: notchRadius,
+        decoration: decoration,
+        sectionHeights: sectionHeights,
+        inset: stitch.inset,
+      );
+      final stitchPaint = _stitchPaint
+        ..color = stitch.color
+        ..strokeWidth = stitch.thickness
+        ..strokeCap = stitch.cap;
+      canvas.drawPath(
+        dashPath(stitchOutline,
+            BorderDash(dash: stitch.length, gap: stitch.spacing)),
+        stitchPaint,
+      );
     }
 
     // Draw dividers between ticket sections. A section's `dividerAfter`

--- a/lib/ticketcher.dart
+++ b/lib/ticketcher.dart
@@ -7,6 +7,7 @@ export 'src/models/punch_hole.dart';
 export 'src/models/section.dart';
 export 'src/models/ticket_divider.dart';
 export 'src/models/ticket_radius.dart';
+export 'src/models/ticket_stitch.dart';
 export 'src/models/ticket_watermark.dart';
 export 'src/models/ticketcher_decoration.dart';
 export 'src/widgets/hticketcher.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ticketcher
 description: "A Flutter package for creating beautiful ticket-style cards with customizable borders, dividers, and patterns. Perfect for event tickets, boarding passes, and coupons."
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/fathialamre/ticketcher
 repository: https://github.com/fathialamre/ticketcher
 topics:

--- a/test/models/decoration_equality_test.dart
+++ b/test/models/decoration_equality_test.dart
@@ -102,5 +102,23 @@ void main() {
       // hashCode collision would be legal, so only equality is asserted.
       expect(withNull, isNot(equals(withEmpty)));
     });
+
+    test('differing stitch ⇒ unequal; content-equal ⇒ equal', () {
+      const a = TicketcherDecoration(stitch: TicketStitch(inset: 10));
+      const b = TicketcherDecoration(stitch: TicketStitch(inset: 14));
+      const c = TicketcherDecoration(stitch: TicketStitch(inset: 10));
+      expect(a, isNot(equals(b)));
+      expect(a, equals(c));
+      expect(a.hashCode, c.hashCode);
+    });
+
+    test('copyWith round-trips stitch', () {
+      const a = TicketcherDecoration(stitch: TicketStitch(inset: 10));
+      expect(a.copyWith(), equals(a));
+      expect(
+        a.copyWith(stitch: const TicketStitch(inset: 20)).stitch,
+        const TicketStitch(inset: 20),
+      );
+    });
   });
 }

--- a/test/models/ticket_stitch_test.dart
+++ b/test/models/ticket_stitch_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ticketcher/ticketcher.dart';
+
+void main() {
+  group('TicketStitch', () {
+    test('equal values ⇒ equal and same hashCode', () {
+      const a = TicketStitch(color: Colors.white, inset: 10, length: 6, spacing: 6);
+      const b = TicketStitch(color: Colors.white, inset: 10, length: 6, spacing: 6);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('differing fields ⇒ unequal', () {
+      const base = TicketStitch();
+      expect(base, isNot(equals(const TicketStitch(color: Colors.black))));
+      expect(base, isNot(equals(const TicketStitch(inset: 14))));
+      expect(base, isNot(equals(const TicketStitch(length: 8))));
+      expect(base, isNot(equals(const TicketStitch(spacing: 8))));
+      expect(base, isNot(equals(const TicketStitch(thickness: 3))));
+      expect(base, isNot(equals(const TicketStitch(cap: StrokeCap.butt))));
+    });
+
+    test('copyWith replaces only given fields', () {
+      const a = TicketStitch(inset: 10, length: 6);
+      final b = a.copyWith(length: 9);
+      expect(b.inset, 10);
+      expect(b.length, 9);
+      expect(a.copyWith(), equals(a));
+    });
+
+    test('defaults are white / round-cap / 10-6-6-2', () {
+      const a = TicketStitch();
+      expect(a.color, Colors.white);
+      expect(a.inset, 10);
+      expect(a.length, 6);
+      expect(a.spacing, 6);
+      expect(a.thickness, 2);
+      expect(a.cap, StrokeCap.round);
+    });
+
+    test('non-positive or non-finite numeric fields assert', () {
+      expect(() => TicketStitch(inset: 0), throwsAssertionError);
+      expect(() => TicketStitch(length: 0), throwsAssertionError);
+      expect(() => TicketStitch(spacing: -1), throwsAssertionError);
+      expect(() => TicketStitch(thickness: 0), throwsAssertionError);
+      expect(() => TicketStitch(inset: double.infinity), throwsAssertionError);
+      expect(() => TicketStitch(length: double.nan), throwsAssertionError);
+    });
+  });
+}

--- a/test/painters/should_repaint_test.dart
+++ b/test/painters/should_repaint_test.dart
@@ -132,6 +132,16 @@ void main() {
       );
       expect(b.shouldRepaint(a), isTrue);
     });
+
+    test('different stitch ⇒ true', () {
+      final a = _vp();
+      final b = _vp(
+        decoration: const TicketcherDecoration(
+          stitch: TicketStitch(color: Colors.white, inset: 10),
+        ),
+      );
+      expect(b.shouldRepaint(a), isTrue);
+    });
   });
 
   group('HTicketcherPainter.shouldRepaint', () {
@@ -196,6 +206,16 @@ void main() {
           ),
           const Section(child: Text('B')),
         ],
+      );
+      expect(b.shouldRepaint(a), isTrue);
+    });
+
+    test('different stitch ⇒ true', () {
+      final a = _hp();
+      final b = _hp(
+        decoration: const TicketcherDecoration(
+          stitch: TicketStitch(color: Colors.white, inset: 10),
+        ),
       );
       expect(b.shouldRepaint(a), isTrue);
     });

--- a/test/painters/stitch_draw_test.dart
+++ b/test/painters/stitch_draw_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ticketcher/ticketcher.dart';
+import 'package:ticketcher/src/painters/vticketcher_painter.dart';
+import 'package:ticketcher/src/painters/hticketcher_painter.dart';
+
+// Records drawPath calls; ignores every other Canvas operation.
+class _RecordingCanvas implements Canvas {
+  int drawPathCount = 0;
+  final List<Paint> drawPathPaints = <Paint>[];
+
+  @override
+  void drawPath(Path path, Paint paint) {
+    drawPathCount++;
+    drawPathPaints.add(paint);
+  }
+
+  @override
+  void noSuchMethod(Invocation invocation) {}
+}
+
+const _sections = <Section>[
+  Section(child: Text('A')),
+  Section(child: Text('B')),
+];
+
+void main() {
+  test('VTicketcherPainter draws an extra stroked path when stitch is set', () {
+    const size = Size(300, 400);
+
+    final without = _RecordingCanvas();
+    VTicketcherPainter(
+      notchRadius: 10,
+      sectionHeights: const [200, 200],
+      decoration: const TicketcherDecoration(),
+      sections: _sections,
+    ).paint(without, size);
+
+    final withStitch = _RecordingCanvas();
+    VTicketcherPainter(
+      notchRadius: 10,
+      sectionHeights: const [200, 200],
+      decoration: const TicketcherDecoration(
+        stitch: TicketStitch(color: Colors.white, inset: 10),
+      ),
+      sections: _sections,
+    ).paint(withStitch, size);
+
+    expect(withStitch.drawPathCount, greaterThan(without.drawPathCount));
+    expect(
+      withStitch.drawPathPaints.any((p) =>
+          p.style == PaintingStyle.stroke &&
+          p.color == const Color(0xFFFFFFFF)),
+      isTrue,
+    );
+  });
+
+  test('HTicketcherPainter draws an extra stroked path when stitch is set', () {
+    const size = Size(400, 200);
+
+    final without = _RecordingCanvas();
+    HTicketcherPainter(
+      notchRadius: 10,
+      sectionWidths: const [200, 200],
+      decoration: const TicketcherDecoration(),
+      sections: _sections,
+    ).paint(without, size);
+
+    final withStitch = _RecordingCanvas();
+    HTicketcherPainter(
+      notchRadius: 10,
+      sectionWidths: const [200, 200],
+      decoration: const TicketcherDecoration(
+        stitch: TicketStitch(color: Colors.white, inset: 10),
+      ),
+      sections: _sections,
+    ).paint(withStitch, size);
+
+    expect(withStitch.drawPathCount, greaterThan(without.drawPathCount));
+  });
+
+  test('degenerate inset skips the stitch draw (no extra path)', () {
+    const size = Size(60, 400); // shortestSide 60; inset*2 = 400 >= 60 → skip
+
+    final baseline = _RecordingCanvas();
+    VTicketcherPainter(
+      notchRadius: 10,
+      sectionHeights: const [200, 200],
+      decoration: const TicketcherDecoration(),
+      sections: _sections,
+    ).paint(baseline, size);
+
+    final degenerate = _RecordingCanvas();
+    VTicketcherPainter(
+      notchRadius: 10,
+      sectionHeights: const [200, 200],
+      decoration: const TicketcherDecoration(stitch: TicketStitch(inset: 200)),
+      sections: _sections,
+    ).paint(degenerate, size);
+
+    expect(degenerate.drawPathCount, baseline.drawPathCount);
+  });
+}

--- a/test/painters/stitch_draw_test.dart
+++ b/test/painters/stitch_draw_test.dart
@@ -12,7 +12,11 @@ class _RecordingCanvas implements Canvas {
   @override
   void drawPath(Path path, Paint paint) {
     drawPathCount++;
-    drawPathPaints.add(paint);
+    drawPathPaints.add(Paint()
+      ..style = paint.style
+      ..color = paint.color
+      ..strokeWidth = paint.strokeWidth
+      ..strokeCap = paint.strokeCap);
   }
 
   @override
@@ -77,6 +81,12 @@ void main() {
     ).paint(withStitch, size);
 
     expect(withStitch.drawPathCount, greaterThan(without.drawPathCount));
+    expect(
+      withStitch.drawPathPaints.any((p) =>
+          p.style == PaintingStyle.stroke &&
+          p.color == const Color(0xFFFFFFFF)),
+      isTrue,
+    );
   });
 
   test('degenerate inset skips the stitch draw (no extra path)', () {

--- a/test/painters/stitch_path_test.dart
+++ b/test/painters/stitch_path_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ticketcher/ticketcher.dart';
+import 'package:ticketcher/src/painters/ticket_path_builder.dart';
+
+void main() {
+  group('buildVerticalStitchPath', () {
+    final path = TicketPathBuilder.buildVerticalStitchPath(
+      size: const Size(200, 400),
+      notchRadius: 10,
+      decoration: const TicketcherDecoration(),
+      sectionHeights: const [200, 200],
+      inset: 12,
+    );
+
+    test('non-empty path', () {
+      final len = path
+          .computeMetrics()
+          .fold<double>(0, (s, m) => s + m.length);
+      expect(len, greaterThan(0));
+    });
+
+    test('stays within the deflated rect', () {
+      final b = path.getBounds();
+      expect(b.left, greaterThanOrEqualTo(12 - 0.5));
+      expect(b.top, greaterThanOrEqualTo(12 - 0.5));
+      expect(b.right, lessThanOrEqualTo(200 - 12 + 0.5));
+      expect(b.bottom, lessThanOrEqualTo(400 - 12 + 0.5));
+    });
+
+    test('encloses the interior', () {
+      expect(path.contains(const Offset(100, 200)), isTrue);
+      expect(path.contains(const Offset(2, 2)), isFalse);
+    });
+
+    test('notch indents the right edge at the section boundary', () {
+      // Away from the notch the right boundary is the straight inset edge (x=188).
+      expect(path.contains(const Offset(185, 100)), isTrue);
+      // At the notch centre (y=200) the boundary dips inward to x=178.
+      expect(path.contains(const Offset(185, 200)), isFalse);
+    });
+  });
+
+  group('buildHorizontalStitchPath', () {
+    final path = TicketPathBuilder.buildHorizontalStitchPath(
+      size: const Size(400, 200),
+      notchRadius: 10,
+      decoration: const TicketcherDecoration(),
+      sectionWidths: const [200, 200],
+      inset: 12,
+    );
+
+    test('non-empty path within the deflated rect', () {
+      final len = path
+          .computeMetrics()
+          .fold<double>(0, (s, m) => s + m.length);
+      expect(len, greaterThan(0));
+      final b = path.getBounds();
+      expect(b.left, greaterThanOrEqualTo(12 - 0.5));
+      expect(b.right, lessThanOrEqualTo(400 - 12 + 0.5));
+    });
+
+    test('notch indents the top edge at the section boundary', () {
+      expect(path.contains(const Offset(100, 18)), isTrue);
+      expect(path.contains(const Offset(200, 18)), isFalse);
+    });
+  });
+}

--- a/test/painters/stitch_path_test.dart
+++ b/test/painters/stitch_path_test.dart
@@ -58,11 +58,18 @@ void main() {
       final b = path.getBounds();
       expect(b.left, greaterThanOrEqualTo(12 - 0.5));
       expect(b.right, lessThanOrEqualTo(400 - 12 + 0.5));
+      expect(b.top, greaterThanOrEqualTo(12 - 0.5));
+      expect(b.bottom, lessThanOrEqualTo(200 - 12 + 0.5));
     });
 
     test('notch indents the top edge at the section boundary', () {
       expect(path.contains(const Offset(100, 18)), isTrue);
       expect(path.contains(const Offset(200, 18)), isFalse);
+    });
+
+    test('notch indents the bottom edge at the section boundary', () {
+      expect(path.contains(const Offset(100, 182)), isTrue);
+      expect(path.contains(const Offset(200, 182)), isFalse);
     });
   });
 }

--- a/test/widgets/stitch_render_test.dart
+++ b/test/widgets/stitch_render_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ticketcher/ticketcher.dart';
+
+import '../helpers/widget_pump.dart';
+
+const _sections = <Section>[
+  Section(child: Text('A')),
+  Section(child: Text('B')),
+];
+
+void main() {
+  testWidgets('VTicketcher with stitch renders without throwing',
+      (tester) async {
+    await pumpTicket(
+      tester,
+      VTicketcher(
+        width: 300,
+        decoration: const TicketcherDecoration(
+          stitch: TicketStitch(color: Colors.white, inset: 10),
+        ),
+        sections: _sections,
+      ),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('HTicketcher with stitch renders without throwing',
+      (tester) async {
+    await pumpTicket(
+      tester,
+      Ticketcher.horizontal(
+        height: 140,
+        decoration: const TicketcherDecoration(
+          stitch: TicketStitch(color: Colors.white, inset: 10),
+        ),
+        sections: _sections,
+      ),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('stitch coexists with a solid border', (tester) async {
+    await pumpTicket(
+      tester,
+      VTicketcher(
+        width: 300,
+        decoration: TicketcherDecoration(
+          border: Border.all(color: Colors.indigo, width: 2),
+          stitch: const TicketStitch(color: Colors.white, inset: 10),
+        ),
+        sections: _sections,
+      ),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('degenerate inset is skipped without throwing', (tester) async {
+    await pumpTicket(
+      tester,
+      VTicketcher(
+        width: 60,
+        decoration: const TicketcherDecoration(
+          stitch: TicketStitch(inset: 200),
+        ),
+        sections: _sections,
+      ),
+    );
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **stitching border**: `TicketStitch` on `TicketcherDecoration.stitch` draws a dashed "thread" line inset from the ticket edge, following the full outline (rounded corners + section notches), for a sewn / coupon look. Works in both vertical and horizontal orientations and is independent of `border` / `borderDash`. Purely additive — zero breaking changes.

## API

```dart
TicketcherDecoration(
  stitch: TicketStitch(
    color: Colors.white,
    inset: 10,            // gap from edge to the thread line
    length: 6,            // dash (stitch) length
    spacing: 6,           // gap between stitches
    thickness: 2,
    cap: StrokeCap.round, // round = thread look
  ),
)
```

## Implementation

- New value model `lib/src/models/ticket_stitch.dart` (exported from the barrel); `==`/`hashCode`/`copyWith` over all fields; const-evaluable asserts mirroring `BorderDash`.
- `TicketcherDecoration.stitch` threaded through ctor / `copyWith` / `==` / `hashCode` / docs.
- Geometry: `TicketPathBuilder.buildVerticalStitchPath` / `buildHorizontalStitchPath` build the outline offset inward by `inset` — straight edges in by `inset`, corner radius `max(0, r-inset)`, each notch wrapped by a rounded arc of radius `notchRadius+inset` centred on the original notch (junction `sqrt(nr² + 2·nr·inset)`). Border patterns and punch holes are intentionally not traced.
- Both painters draw the inset outline dashed (reusing `dashPath`) on the front face, after the border block, with a degenerate-inset guard (`inset*2 < size.shortestSide`).

Design decisions (documented): single line; whole-ticket outline; notches wrapped with a rounded arc regardless of `notchStyle.shape`; no punch-hole rings; no edge-pattern bulge.

## Tests

123 passing — `TicketStitch` value semantics + asserts, inset-path geometry (bounds + notch indentation, both orientations), `shouldRepaint`, a recording-canvas test asserting the stitch emits a stroked thread draw op (and that the degenerate guard skips it), and V/H render smoke incl. coexistence with a solid border. `flutter analyze` clean for `lib/` and `test/`.

## Docs / release

README "Stitching Border" section + feature list, CHANGELOG `2.2.0`, `pubspec.yaml` → `2.2.0`, and an `example/` showcase (vertical coupon, horizontal discount, border+stitch combo).