### PR TITLE
fix: widget watermark renders as a clipped background layer

### DIFF
--- a/example/lib/show_cases/watermark_showcase.dart
+++ b/example/lib/show_cases/watermark_showcase.dart
@@ -31,9 +31,9 @@ class WatermarkShowcase extends StatelessWidget {
             ),
 
             _buildSection(
-              'Horizontal Icon Watermark',
-              'Icon watermark on horizontal ticket',
-              _buildHorizontalIconWatermark(),
+              'Horizontal Image Watermark',
+              'Image watermark as a clipped background',
+              _buildHorizontalImageWatermark(),
             ),
 
             // Vertical ticket examples
@@ -137,7 +137,7 @@ class WatermarkShowcase extends StatelessWidget {
     );
   }
 
-  Widget _buildHorizontalIconWatermark() {
+  Widget _buildHorizontalImageWatermark() {
     return Ticketcher.horizontal(
       height: 150,
       sections: [
@@ -182,11 +182,19 @@ class WatermarkShowcase extends StatelessWidget {
         backgroundColor: Colors.green.shade50,
         border: Border.all(color: Colors.green.shade200),
         borderRadius: const TicketRadius(radius: 12),
+        // The widget (image) watermark renders as a clipped background layer
+        // behind the section content, spanning the whole ticket.
         watermark: const TicketWatermark.widget(
-          widget: Icon(Icons.flight, size: 60, color: Colors.green),
-          opacity: 0.2,
+          widget: Image(
+            image: NetworkImage(
+              'https://images.unsplash.com/photo-1506905925346-21bda4d32df4',
+            ),
+            fit: BoxFit.cover,
+          ),
+          opacity: 0.25,
           alignment: WatermarkAlignment.center,
-          rotation: 15,
+          width: 320,
+          height: 150,
         ),
       ),
     );

--- a/lib/src/widgets/hticketcher.dart
+++ b/lib/src/widgets/hticketcher.dart
@@ -7,6 +7,7 @@ import '../models/ticket_watermark.dart';
 import '../painters/hticketcher_painter.dart';
 import '../painters/image_resolver.dart';
 import 'blur_wrapper.dart';
+import 'ticket_clipper.dart';
 
 /// A widget that creates a horizontal ticket with customizable sections, borders, and dividers.
 ///
@@ -273,61 +274,74 @@ class _HTicketcherState extends State<HTicketcher> {
                       decorationBackgroundImage: _decorationBackgroundImage,
                       sectionBackgroundImages: _sectionBackgroundImages,
                     ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children:
-                          List.generate(widget.sections.length, (index) {
-                        final section = widget.sections[index];
-                        return Expanded(
-                          flex: (section.widthFactor ?? 1.0).round(),
-                          child: GestureDetector(
-                            onTap: section.onTap,
-                            child: Container(
-                              key: _sectionKeys[index],
-                              padding: section.padding,
-                              child: section.child,
+                    child: _withWidgetWatermark(
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children:
+                            List.generate(widget.sections.length, (index) {
+                          final section = widget.sections[index];
+                          return Expanded(
+                            flex: (section.widthFactor ?? 1.0).round(),
+                            child: GestureDetector(
+                              onTap: section.onTap,
+                              child: Container(
+                                key: _sectionKeys[index],
+                                padding: section.padding,
+                                child: section.child,
+                              ),
                             ),
-                          ),
-                        );
-                      }),
+                          );
+                        }),
+                      ),
                     ),
                   ),
                 ),
               ),
             );
 
-            // Build with overlays (watermark)
-            return _buildWithOverlays(ticketWidget);
+            return ticketWidget;
           },
         ),
       ),
     );
   }
 
-  /// Builds the ticket with all overlays (watermark)
-  Widget _buildWithOverlays(Widget ticketWidget) {
+  /// Wraps the section [content] so a widget watermark renders in the
+  /// background layer — behind the content and clipped to the ticket shape —
+  /// mirroring how text watermarks are painted. Returns [content] unchanged
+  /// when there is no widget watermark.
+  Widget _withWidgetWatermark(Widget content) {
+    final watermark = widget.decoration.watermark;
     final hasWidgetWatermark =
-        widget.decoration.watermark?.type == WatermarkType.widget &&
-        widget.decoration.watermark?.widget != null;
+        watermark?.type == WatermarkType.widget && watermark?.widget != null;
 
     if (!hasWidgetWatermark) {
-      return ticketWidget;
+      return content;
     }
 
     return Stack(
       children: [
-        ticketWidget,
-        if (hasWidgetWatermark)
-          _buildWidgetWatermarkOverlay(widget.decoration.watermark!),
+        Positioned.fill(
+          child: ClipPath(
+            clipper: HTicketcherClipper(
+              notchRadius: widget.notchRadius,
+              decoration: widget.decoration,
+              sectionWidths: _sectionWidths,
+            ),
+            child: _buildWidgetWatermark(watermark!),
+          ),
+        ),
+        content,
       ],
     );
   }
 
-  /// Builds the widget watermark overlay
+  /// Builds the styled, aligned widget watermark (size, opacity, rotation,
+  /// offset, alignment). Positioning and clipping are handled by the caller.
   ///
   /// Note: Widget watermarks do not support repeat functionality.
   /// Only text watermarks support repeating patterns.
-  Widget _buildWidgetWatermarkOverlay(TicketWatermark watermark) {
+  Widget _buildWidgetWatermark(TicketWatermark watermark) {
     Widget watermarkWidget = watermark.widget!;
 
     // Apply size constraints if specified
@@ -361,12 +375,10 @@ class _HTicketcherState extends State<HTicketcher> {
       );
     }
 
-    // Apply alignment and create positioned widget
-    return Positioned.fill(
-      child: Align(
-        alignment: watermark.flutterAlignment,
-        child: watermarkWidget,
-      ),
+    // Align within the (clipped) full-ticket bounds.
+    return Align(
+      alignment: watermark.flutterAlignment,
+      child: watermarkWidget,
     );
   }
 }

--- a/lib/src/widgets/vticketcher.dart
+++ b/lib/src/widgets/vticketcher.dart
@@ -8,6 +8,7 @@ import '../models/ticket_watermark.dart';
 import '../painters/vticketcher_painter.dart';
 import '../painters/image_resolver.dart';
 import 'blur_wrapper.dart';
+import 'ticket_clipper.dart';
 
 /// A widget that creates a vertical ticket with customizable sections, borders, and dividers.
 ///
@@ -293,58 +294,71 @@ class _VTicketcherState extends State<VTicketcher> {
                       decorationBackgroundImage: _decorationBackgroundImage,
                       sectionBackgroundImages: _sectionBackgroundImages,
                     ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children:
-                          List.generate(widget.sections.length, (index) {
-                        final section = widget.sections[index];
-                        return GestureDetector(
-                          onTap: section.onTap,
-                          child: Container(
-                            key: _sectionKeys[index],
-                            padding: section.padding,
-                            child: section.child,
-                          ),
-                        );
-                      }),
+                    child: _withWidgetWatermark(
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children:
+                            List.generate(widget.sections.length, (index) {
+                          final section = widget.sections[index];
+                          return GestureDetector(
+                            onTap: section.onTap,
+                            child: Container(
+                              key: _sectionKeys[index],
+                              padding: section.padding,
+                              child: section.child,
+                            ),
+                          );
+                        }),
+                      ),
                     ),
                   ),
                 ),
               ),
             );
 
-            // Build with overlays (watermark)
-            return _buildWithOverlays(ticketWidget);
+            return ticketWidget;
           },
         ),
       ),
     );
   }
 
-  /// Builds the ticket with all overlays (watermark)
-  Widget _buildWithOverlays(Widget ticketWidget) {
+  /// Wraps the section [content] so a widget watermark renders in the
+  /// background layer — behind the content and clipped to the ticket shape —
+  /// mirroring how text watermarks are painted. Returns [content] unchanged
+  /// when there is no widget watermark.
+  Widget _withWidgetWatermark(Widget content) {
+    final watermark = widget.decoration.watermark;
     final hasWidgetWatermark =
-        widget.decoration.watermark?.type == WatermarkType.widget &&
-        widget.decoration.watermark?.widget != null;
+        watermark?.type == WatermarkType.widget && watermark?.widget != null;
 
     if (!hasWidgetWatermark) {
-      return ticketWidget;
+      return content;
     }
 
     return Stack(
       children: [
-        ticketWidget,
-        if (hasWidgetWatermark)
-          _buildWidgetWatermarkOverlay(widget.decoration.watermark!),
+        Positioned.fill(
+          child: ClipPath(
+            clipper: VTicketcherClipper(
+              notchRadius: widget.notchRadius,
+              decoration: widget.decoration,
+              sectionHeights: _sectionHeights,
+            ),
+            child: _buildWidgetWatermark(watermark!),
+          ),
+        ),
+        content,
       ],
     );
   }
 
-  /// Builds the widget watermark overlay
+  /// Builds the styled, aligned widget watermark (size, opacity, rotation,
+  /// offset, alignment). Positioning and clipping are handled by the caller.
   ///
   /// Note: Widget watermarks do not support repeat functionality.
   /// Only text watermarks support repeating patterns.
-  Widget _buildWidgetWatermarkOverlay(TicketWatermark watermark) {
+  Widget _buildWidgetWatermark(TicketWatermark watermark) {
     Widget watermarkWidget = watermark.widget!;
 
     // Apply size constraints if specified
@@ -378,12 +392,10 @@ class _VTicketcherState extends State<VTicketcher> {
       );
     }
 
-    // Apply alignment and create positioned widget
-    return Positioned.fill(
-      child: Align(
-        alignment: watermark.flutterAlignment,
-        child: watermarkWidget,
-      ),
+    // Align within the (clipped) full-ticket bounds.
+    return Align(
+      alignment: watermark.flutterAlignment,
+      child: watermarkWidget,
     );
   }
 }

--- a/test/widgets/watermark_layer_test.dart
+++ b/test/widgets/watermark_layer_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ticketcher/ticketcher.dart';
+import 'package:ticketcher/src/painters/vticketcher_painter.dart';
+import 'package:ticketcher/src/painters/hticketcher_painter.dart';
+
+import '../helpers/widget_pump.dart';
+
+const _wmKey = Key('wm');
+
+const _sections = <Section>[
+  Section(child: Text('A')),
+  Section(child: Text('B')),
+];
+
+const _watermark = TicketWatermark.widget(
+  widget: SizedBox(
+    key: _wmKey,
+    width: 24,
+    height: 24,
+    child: ColoredBox(color: Color(0xFFFF0000)),
+  ),
+  alignment: WatermarkAlignment.center,
+  opacity: 0.5,
+);
+
+void main() {
+  testWidgets(
+    'vertical: widget watermark renders in the background layer, clipped to the ticket shape',
+    (tester) async {
+      await pumpTicket(
+        tester,
+        VTicketcher(
+          width: 300,
+          decoration: const TicketcherDecoration(watermark: _watermark),
+          sections: _sections,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(_wmKey), findsOneWidget);
+
+      // Background layer: the watermark lives INSIDE the painter's CustomPaint
+      // (behind the section content), not as a foreground sibling overlay.
+      final painter = find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is VTicketcherPainter,
+      );
+      expect(
+        find.descendant(of: painter, matching: find.byKey(_wmKey)),
+        findsOneWidget,
+      );
+
+      // Clipped to the ticket outline (notches + corners).
+      final clip = find.byWidgetPredicate(
+        (w) => w is ClipPath && w.clipper is VTicketcherClipper,
+      );
+      expect(
+        find.ancestor(of: find.byKey(_wmKey), matching: clip),
+        findsAtLeastNWidgets(1),
+      );
+    },
+  );
+
+  testWidgets(
+    'horizontal: widget watermark renders in the background layer, clipped to the ticket shape',
+    (tester) async {
+      await pumpTicket(
+        tester,
+        Ticketcher.horizontal(
+          height: 160,
+          decoration: const TicketcherDecoration(watermark: _watermark),
+          sections: _sections,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(_wmKey), findsOneWidget);
+
+      final painter = find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is HTicketcherPainter,
+      );
+      expect(
+        find.descendant(of: painter, matching: find.byKey(_wmKey)),
+        findsOneWidget,
+      );
+
+      final clip = find.byWidgetPredicate(
+        (w) => w is ClipPath && w.clipper is HTicketcherClipper,
+      );
+      expect(
+        find.ancestor(of: find.byKey(_wmKey), matching: clip),
+        findsAtLeastNWidgets(1),
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Problem

Widget watermarks (`TicketWatermark.widget`) appeared on top of content and confined to one section instead of acting as a whole-widget background.

## Root cause

`_buildWithOverlays` wrapped the ticket in `Stack([ ticketWidget, Positioned.fill(Align(watermark)) ])`, so the widget watermark was a **foreground** overlay (painted after the ticket), positioned by `alignment` to a corner/center, and **not clipped** to the ticket shape. A `bottomRight`/`center` watermark therefore sat over a single section, in front of content. Text watermarks don't have this problem — the painter draws them behind content across the whole ticket.

## Fix

Move the widget watermark into the painter's `CustomPaint` child, **behind** the section content, wrapped in `ClipPath` with the existing `VTicketcherClipper` / `HTicketcherClipper`. It now renders as a background layer clipped to the ticket outline (notches + corners), spanning the whole widget — mirroring text-watermark layering. Alignment, size, opacity, rotation, and offset still apply. Mirrored in both `vticketcher.dart` and `hticketcher.dart`.

## Tests

New `test/widgets/watermark_layer_test.dart` (vertical + horizontal) asserts the watermark is a descendant of the painter's `CustomPaint` (background layer, not a foreground sibling) and has a `*TicketcherClipper` `ClipPath` ancestor (clipped to shape). Fails before the fix, passes after.

Full suite: 125 passing. `flutter analyze lib test`: no issues.